### PR TITLE
Add support to 2024.2, still incomplete*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,15 +5,15 @@ plugins {
 }
 
 group = "EditorGroups"
-version = "0.47"
+version = "0.48"
 
 tasks {
     patchPluginXml {
-        sinceBuild.set("231")
-        untilBuild.set("231.*")
+        sinceBuild.set("242")
+        untilBuild.set("242.*")
         changeNotes.set(
             buildString {
-                append("- Icons fix").append("<br>")
+                append("- Add support to 2024.2;").append("<br>").append("- Fix deprecations warnings;")
             }
         )
     }
@@ -54,12 +54,12 @@ repositories {
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-    version.set("2023.1")
+    version.set("2024.2")
     type.set("IC") // Target IDE Platform
+    downloadSources.set(true)
 
     plugins.set(listOf("java"))
 }
-
 
 dependencies {
 // https://mvnrepository.com/artifact/commons-io/commons-io

--- a/src/main/java/krasa/editorGroups/UniqueTabNameBuilder.java
+++ b/src/main/java/krasa/editorGroups/UniqueTabNameBuilder.java
@@ -1,9 +1,9 @@
 package krasa.editorGroups;
 
+import com.intellij.filename.UniqueNameBuilder;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
-import com.intellij.openapi.util.io.UniqueNameBuilder;
 import com.intellij.openapi.vfs.VirtualFile;
 import gnu.trove.THashMap;
 import gnu.trove.THashSet;
@@ -24,7 +24,7 @@ public class UniqueTabNameBuilder {
 	}
 
 	public Map<Link, String> getNamesByPath(List<Link> paths, VirtualFile currentFile) {
-		UniqueNameBuilder<Link> uniqueNameBuilder = new UniqueNameBuilder<>(root, "/", 25);
+		UniqueNameBuilder<Link> uniqueNameBuilder = new UniqueNameBuilder<>(root, "/");
 		Map<Link, String> path_name = new THashMap<>();
 		Map<String, Link> name_path = new THashMap<>();
 		Set<Link> paths_withDuplicateName = new THashSet<>();

--- a/src/main/java/krasa/editorGroups/gui/RegexModelEditor.java
+++ b/src/main/java/krasa/editorGroups/gui/RegexModelEditor.java
@@ -17,7 +17,7 @@ import com.intellij.ui.EnumComboBoxModel;
 import com.intellij.ui.ErrorLabel;
 import com.intellij.ui.components.JBTextField;
 import krasa.editorGroups.model.RegexGroupModel;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/krasa/editorGroups/gui/TabsColors.java
+++ b/src/main/java/krasa/editorGroups/gui/TabsColors.java
@@ -1,8 +1,8 @@
 package krasa.editorGroups.gui;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.ui.JBColor;
 import com.intellij.util.ui.JBDimension;
-import com.intellij.util.ui.UIUtil;
 import krasa.editorGroups.ApplicationConfiguration;
 import krasa.editorGroups.support.CheckBoxWithColorChooser;
 
@@ -39,8 +39,9 @@ public class TabsColors {
 	}
 
 	public TabsColors() {
-		darcula.setVisible(UIUtil.isUnderDarcula());
-		classic.setVisible(!UIUtil.isUnderDarcula());
+
+		darcula.setVisible(!JBColor.isBright());
+		classic.setVisible(JBColor.isBright());
 
 		opacityDefault.addActionListener(new ActionListener() {
 			@Override

--- a/src/main/java/krasa/editorGroups/support/CheckBoxWithColorChooser.java
+++ b/src/main/java/krasa/editorGroups/support/CheckBoxWithColorChooser.java
@@ -16,7 +16,7 @@
 package krasa.editorGroups.support;
 
 import com.intellij.openapi.util.SystemInfo;
-import com.intellij.ui.ColorChooser;
+import com.intellij.ui.ColorChooserService;
 import com.intellij.ui.JBColor;
 
 import javax.swing.*;
@@ -132,8 +132,8 @@ public class CheckBoxWithColorChooser extends JPanel {
 			mouseAdapter = new MouseAdapter() {
 				@Override
 				public void mousePressed(MouseEvent e) {
-					final Color color = ColorChooser.chooseColor(MyColorButton.this, "Chose color",
-						CheckBoxWithColorChooser.this.myColor);
+					final Color color = ColorChooserService.getInstance().showDialog(MyColorButton.this,
+							"Choose Color", CheckBoxWithColorChooser.this.myColor);
 					if (color != null) {
 						if (myCheckbox != null && !myCheckbox.isSelected()) {
 							myCheckbox.setSelected(true);

--- a/src/main/java/krasa/editorGroups/tabs2/TabInfo.java
+++ b/src/main/java/krasa/editorGroups/tabs2/TabInfo.java
@@ -21,7 +21,6 @@ import com.intellij.openapi.editor.markup.TextAttributes;
 import com.intellij.openapi.ui.Queryable;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.reference.SoftReference;
-import com.intellij.ui.IconDeferrer;
 import com.intellij.ui.PlaceProvider;
 import com.intellij.ui.SimpleColoredText;
 import com.intellij.ui.SimpleTextAttributes;
@@ -37,6 +36,7 @@ import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class TabInfo implements Queryable, PlaceProvider {
 
@@ -149,7 +149,7 @@ public class TabInfo implements Queryable, PlaceProvider {
 	@NotNull
 	public TabInfo setIcon(Icon icon) {
 		Icon old = myIcon;
-		if (!IconDeferrer.getInstance().equalIcons(old, icon)) {
+		if (!Objects.equals(old, icon)) {
 			myIcon = icon;
 			myChangeSupport.firePropertyChange(ICON, old, icon);
 		}

--- a/src/main/java/krasa/editorGroups/tabs2/impl/ActionButton.java
+++ b/src/main/java/krasa/editorGroups/tabs2/impl/ActionButton.java
@@ -2,7 +2,11 @@
 package krasa.editorGroups.tabs2.impl;
 
 import com.intellij.ide.DataManager;
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.ActionPlaces;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.openapi.actionSystem.ex.ActionUtil;
 import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.ui.popup.IconButton;
@@ -12,7 +16,11 @@ import com.intellij.util.ui.TimedDeadzone;
 import krasa.editorGroups.tabs2.TabInfo;
 
 import java.awt.*;
-import java.awt.event.*;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 import java.util.function.Consumer;
 
 class ActionButton extends IconButton implements ActionListener {
@@ -113,7 +121,7 @@ class ActionButton extends IconButton implements ActionListener {
 	public void actionPerformed(final ActionEvent e) {
 		AnActionEvent event = createAnEvent(e.getModifiers());
 		if (ActionUtil.lastUpdateAndCheckDumb(myAction, event, true)) {
-			ActionUtil.performActionDumbAware(myAction, event);
+			ActionUtil.performActionDumbAwareWithCallbacks(myAction, event);
 		}
 	}
 


### PR DESCRIPTION
**Adds support to 2024.2.* versions;**

This PR still has deprecation problems related to Favorite classes that show errors on IDE startup.
- FavoritesManager (`com.intellij.ide.favoritesTreeView.FavoritesManager`);

### Changes made to fix deprecation of certain classes or methods:
- `com.intellij.openapi.util.io.UniqueNameBuilder` -> `com.intellij.filename.UniqueNameBuilder`;
- `org.apache.commons.lang.StringUtils` -> `org.apache.commons.lang3.StringUtils`;
- `com.intellij.ui.JBColor` -> `com.intellij.util.ui.UIUtil`;
- `com.intellij.ui.ColorChooser` -> `com.intellij.ui.ColorChooserService`;
- Remove use of `IconDeferrer`, manually check if icons are equal;
- `ActionUtil.performActionDumbAware(myAction, event)` -> `ActionUtil.performActionDumbAwareWithCallbacks(myAction, event)`